### PR TITLE
add error handling to requests.get commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ logs
 azure_logs
 __pycache__
 dbclient/*.pyc
+build/
+databricks_migration.egg-info/
+dist/

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,7 @@
+# outer __init__.py
+from . cron-descriptor import cron-descriptor
+from dbclient import *
+from timeit import default_timer as timer
+from datetime import timedelta
+from os import makedirs, path
+from datetime import datetime

--- a/dbclient/HiveClient.py
+++ b/dbclient/HiveClient.py
@@ -23,11 +23,13 @@ class HiveClient(dbclient):
         """ Launches a cluster to get DDL statements.
         Returns a cluster_id """
         version = self.get_latest_spark_version()
+        import os
+        real_path = os.path.dirname(os.path.realpath(__file__))
         if self.is_aws():
-            with open('data/aws_cluster.json', 'r') as fp:
+            with open(real_path+'/../data/aws_cluster.json', 'r') as fp:
                 cluster_json = json.loads(fp.read())
         else:
-            with open('data/azure_cluster.json', 'r') as fp:
+            with open(real_path+'/../data/azure_cluster.json', 'r') as fp:
                 cluster_json = json.loads(fp.read())
         # set the latest spark release regardless of defined cluster json
         cluster_json['spark_version'] = version['key']

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -49,9 +49,15 @@ class dbclient:
             print("Get: {0}".format(full_endpoint))
         if json_params:
             raw_results = requests.get(full_endpoint, headers=self._token, params=json_params)
+            http_status_code = raw_results.status_code
+            if http_status_code != 200:
+                raise Exception("Error. GET request failed with code {}\n{}".format(http_status_code, raw_results.text))
             results = raw_results.json()
         else:
             raw_results = requests.get(full_endpoint, headers=self._token)
+            http_status_code = raw_results.status_code
+            if http_status_code != 200:
+                raise Exception("Error. GET request failed with code {}\n{}".format(http_status_code, raw_results.text))
             results = raw_results.json()
         if print_json:
             print(json.dumps(results, indent=4, sort_keys=True))

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ setuptools.setup(
     url="https://github.com/mrchristine/db-migration",
     license="http://www.apache.org/licenses/LICENSE-2.0",
     packages=setuptools.find_packages(),
+    install_requires=[
+          'cron-descriptor',
+      ],
     py_modules=["export_db","import_db","test_connection"],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="databricks-migration", # Replace with your own username
+    version="0.0.1",
+    author="Miklos C",
+    author_email="miklos.christine@databricks.com",
+    description="Databricks Migration scripts",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/mrchristine/db-migration",
+    packages=setuptools.find_packages(),
+    py_modules=["export_db","import_db","test_connection"],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/mrchristine/db-migration",
+    license="http://www.apache.org/licenses/LICENSE-2.0",
     packages=setuptools.find_packages(),
     py_modules=["export_db","import_db","test_connection"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="databricks-migration", # Replace with your own username
-    version="0.0.1",
+    version="0.0.2",
     author="Miklos C",
     author_email="miklos.christine@databricks.com",
     description="Databricks Migration scripts",
@@ -16,6 +16,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
           'cron-descriptor',
+          'requests'
       ],
     py_modules=["export_db","import_db","test_connection"],
     classifiers=[


### PR DESCRIPTION
When I had expired PAT token, I was receiving a python error instead of seeing the 403 code and resulting HTML text. Added response code checking to GET requests.