### PR TITLE
Allow users to specify existing clusters when performing metastore export

### DIFF
--- a/dbclient/HiveClient.py
+++ b/dbclient/HiveClient.py
@@ -142,9 +142,12 @@ class HiveClient(ClustersClient):
         else:
             print("No registered instance profiles to retry export")
 
-    def export_hive_metastore(self, ms_dir='metastore/'):
+    def export_hive_metastore(self, cluster_name = None, ms_dir='metastore/'):
         start = timer()
-        cid = self.launch_cluster()
+        if cluster_name:
+            cid = self.start_cluster_by_name(cluster_name)
+        else:
+            cid = self.launch_cluster()
         end = timer()
         print("Cluster creation time: " + str(timedelta(seconds=end - start)))
         time.sleep(5)

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -82,6 +82,10 @@ def get_export_parser():
     parser.add_argument('--metastore', action='store_true',
                         help='log all the metastore table definitions')
 
+    # cluster name used to import the metastore
+    parser.add_argument('--cluster-name', action='store',
+                        help='Cluster name to import the metastore to a specific cluster. Cluster will be started.')
+
     # get database to export for metastore
     parser.add_argument('--database', action='store',
                         help='Database name to export for the metastore. Single database name supported')

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -82,9 +82,9 @@ def get_export_parser():
     parser.add_argument('--metastore', action='store_true',
                         help='log all the metastore table definitions')
 
-    # cluster name used to import the metastore
+    # cluster name used to export the metastore
     parser.add_argument('--cluster-name', action='store',
-                        help='Cluster name to import the metastore to a specific cluster. Cluster will be started.')
+                        help='Cluster name to export the metastore to a specific cluster. Cluster will be started.')
 
     # get database to export for metastore
     parser.add_argument('--database', action='store',

--- a/export_db.py
+++ b/export_db.py
@@ -129,10 +129,10 @@ def main():
         if args.database is not None:
             # export only a single database with a given iam role
             database_name = args.database
-            hive_c.export_database(database_name, args.iam)
+            hive_c.export_database(database_name, args.cluster_name, args.iam)
         else:
             # export all of the metastore
-            hive_c.export_hive_metastore()
+            hive_c.export_hive_metastore(cluster_name=args.cluster_name)
         end = timer()
         print("Complete Metastore Export Time: " + str(timedelta(seconds=end - start)))
 


### PR DESCRIPTION
Linked to issue #13 , this PR brings parity to specifying cluster names for exporting a metastore, where the ability already exists when importing a metastore.

This is especially helpful for users who need to specify custom metastore configurations when exporting metastore contents.

